### PR TITLE
Fix ios duration

### DIFF
--- a/ios/AudioManagerModule.swift
+++ b/ios/AudioManagerModule.swift
@@ -44,7 +44,7 @@ class AudioManagerModule: NSObject, AVAudioPlayerDelegate {
                 audioPlayer = try AVAudioPlayer(contentsOf: url)
                 if audioPlayer.prepareToPlay() {
                     self.path = path
-                    resolve(audioPlayer.duration)
+                    resolve(audioPlayer.duration * 1000)
 
                 } else {
                     resolve(false)


### PR DESCRIPTION
iOS method to get duration of an audio returns the time in seconds. This fixes the return to JS for being miliseconds